### PR TITLE
Fix missing '$' sign in 'Set CUDA Path' module

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Setup manually
 $ echo "export PATH=/usr/local/cuda/bin:\${PATH}" >> ${HOME}/.bashrc
 $ echo "export LD_LIBRARY_PATH=/usr/local/cuda/lib64:\${LD_LIBRARY_PATH}" >> ${HOME}/.bashrc
 $ echo "export CPATH=$CPATH:/usr/local/cuda/targets/aarch64-linux/include" >> ${HOME}/.bashrc
-$ echo "export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/targets/aarch64-linux/lib" >> {HOME}/.bashrc
+$ echo "export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/targets/aarch64-linux/lib" >> ${HOME}/.bashrc
 $ source ~/.bashrc
 ```
 


### PR DESCRIPTION
“echo "export LIBRARY_PATH=$LIBRARY_PATH:/usr/local/cuda/targets/aarch64-linux/lib" >> {HOME}/.bashrc” in 'Set CUDA Path' module,missing a '$' sign before {HOME}.